### PR TITLE
Remove the sudden change of height on header transform

### DIFF
--- a/src/shared/Header/HeaderStyle.ts
+++ b/src/shared/Header/HeaderStyle.ts
@@ -41,6 +41,7 @@ export const Inner = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
+  height: 3rem;
 
   a {
     transition: 0.2s ease-in-out;


### PR DESCRIPTION
Before:

https://user-images.githubusercontent.com/22645979/106215527-742b8380-61d1-11eb-8148-bf9fe8dda78c.mov

After:

https://user-images.githubusercontent.com/22645979/106215498-68d85800-61d1-11eb-8fa0-1ec7f15337fc.mov

---

Small cosmetic change, but it looks much better now :smile: