### PR TITLE
Don't show back button on first survey question

### DIFF
--- a/src/components/Survey/SingleSurveyPage/SurveyHeader/SurveyHeaderStyle.ts
+++ b/src/components/Survey/SingleSurveyPage/SurveyHeader/SurveyHeaderStyle.ts
@@ -17,7 +17,11 @@ export const Actions = styled.div`
   align-items: center;
 `;
 
-export const Button = styled.div<{ warning?: boolean; hasText?: boolean }>`
+export const Button = styled.button<{
+  warning?: boolean;
+  hasText?: boolean;
+}>`
+  border: 0;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -45,6 +49,11 @@ export const Button = styled.div<{ warning?: boolean; hasText?: boolean }>`
   &:hover {
     background: ${({ theme }) =>
       transparentize(0.5, theme.colors.backgroundDarken)};
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
   }
 
   ${({ hasText }) =>

--- a/src/components/Survey/SingleSurveyPage/SurveyHeader/SurveyHeaderView.tsx
+++ b/src/components/Survey/SingleSurveyPage/SurveyHeader/SurveyHeaderView.tsx
@@ -20,7 +20,7 @@ const SurveyHeader: React.FC<Props> = ({ actions, data }) => {
   const [confirmReset, setConfirmReset] = useState<boolean>(false);
   const { value: firstTimer, setValue: setFirstTimer } = useFirstTimer();
   const { previousQuestion, deleteSurvey } = actions;
-  const { answers, questions } = data;
+  const { currentQuestion, answers, questions } = data;
   const answeredMany = answers.length > 15;
 
   useEffect(() => {
@@ -41,12 +41,16 @@ const SurveyHeader: React.FC<Props> = ({ actions, data }) => {
     }
   };
 
+  const isFirstQuestion = currentQuestion.id === questions[0].id;
+
   return (
     <Container>
       <Actions>
-        <Button onClick={previousQuestion} title="Poprzednie pytanie">
-          <FontAwesomeIcon icon={faArrowLeft} />
-        </Button>
+        {!isFirstQuestion && (
+          <Button onClick={previousQuestion} title="Poprzednie pytanie">
+            <FontAwesomeIcon icon={faArrowLeft} />
+          </Button>
+        )}
         <Button
           hasText={confirmReset}
           onClick={handleConfirmReset}

--- a/src/components/Survey/SingleSurveyPage/SurveyHeader/SurveyHeaderView.tsx
+++ b/src/components/Survey/SingleSurveyPage/SurveyHeader/SurveyHeaderView.tsx
@@ -46,12 +46,15 @@ const SurveyHeader: React.FC<Props> = ({ actions, data }) => {
   return (
     <Container>
       <Actions>
-        {!isFirstQuestion && (
-          <Button onClick={previousQuestion} title="Poprzednie pytanie">
-            <FontAwesomeIcon icon={faArrowLeft} />
-          </Button>
-        )}
         <Button
+          disabled={isFirstQuestion}
+          onClick={previousQuestion}
+          title="Poprzednie pytanie"
+        >
+          <FontAwesomeIcon icon={faArrowLeft} />
+        </Button>
+        <Button
+          disabled={isFirstQuestion}
           hasText={confirmReset}
           onClick={handleConfirmReset}
           title="Rozpocznij od nowa"


### PR DESCRIPTION
It doesn't make much sense to show the back button on first survey question as there's nowhere to go back to. This PR hides that button on first question.
![obraz](https://user-images.githubusercontent.com/12448522/110011534-da02b200-7d1f-11eb-8bfe-edc3e17c988e.png)
