### PR TITLE
Fix showing article publication date

### DIFF
--- a/src/services/ghost/queries/getSinglePost.ts
+++ b/src/services/ghost/queries/getSinglePost.ts
@@ -10,6 +10,7 @@ const defaultOptions: Params = {
     "excerpt",
     "custom_excerpt",
     "html",
+    "published_at",
   ],
   include: ["tags", "authors"],
   order: "published_at DESC",


### PR DESCRIPTION
Without this every article defaulted to displaying today's date as "published_at" wasn't fetched.