### PR TITLE
Wrap QuizLink features

### DIFF
--- a/src/components/Quiz/QuizLink/QuizLinkStyle.ts
+++ b/src/components/Quiz/QuizLink/QuizLinkStyle.ts
@@ -43,6 +43,7 @@ export const Image = styled.img`
 
 export const FeaturesList = styled.div`
   display: flex;
+  flex-wrap: wrap;
 
   ${breakpoint("xs", "md")`
     display: block;
@@ -59,6 +60,7 @@ export const Chip = styled.div`
   font-weight: ${({ theme }) => theme.fontWeight.secondary.bold};
   font-family: ${({ theme }) => theme.fontFamily.secondary};
   line-height: 1rem;
+  margin-bottom: 0.5rem;
   margin-right: 0.5rem;
 
   ${breakpoint("xs", "md")`


### PR DESCRIPTION
Before:
![obraz](https://user-images.githubusercontent.com/12448522/112040542-a0b2aa80-8b45-11eb-8a2c-d3e8ba81b04d.png)
After:
![obraz](https://user-images.githubusercontent.com/12448522/112040549-a4dec800-8b45-11eb-8af9-e1035521977f.png)
__Potentially__ fixes #70 