### PR TITLE
Fix sign in / sign up page title

### DIFF
--- a/src/pages/auth/index.tsx
+++ b/src/pages/auth/index.tsx
@@ -4,14 +4,14 @@ import CenteredPage from "@shared/CenteredPage";
 import { LoginPage as Page } from "@components/Auth";
 import GoogleAd from "@shared/GoogleAd";
 import useTranslation from "next-translate/useTranslation";
-import { titleTemplate } from '@constants';
+import { titleTemplate } from "@constants";
 
 const LoginPage: React.FC = () => {
   const { t } = useTranslation("auth");
 
   return (
     <CenteredPage fullWidth={false}>
-      <NextSeo title={t("SEO.title")} titleTemplate={titleTemplate} />
+      <NextSeo title={t("SEO.login")} titleTemplate={titleTemplate} />
       <GoogleAd id="myp3-standard-top" />
       <Page />
       <GoogleAd id="myp3-standard-bottom" />

--- a/src/pages/auth/signup.tsx
+++ b/src/pages/auth/signup.tsx
@@ -4,14 +4,14 @@ import CenteredPage from "@shared/CenteredPage";
 import { SignupPage as Page } from "@components/Auth";
 import GoogleAd from "@shared/GoogleAd";
 import useTranslation from "next-translate/useTranslation";
-import { titleTemplate } from '@constants';
+import { titleTemplate } from "@constants";
 
 const SignupPage: React.FC = () => {
   const { t } = useTranslation("auth");
 
   return (
     <CenteredPage fullWidth={false}>
-      <NextSeo title={t("SEO.title")} titleTemplate={titleTemplate} />
+      <NextSeo title={t("SEO.signUp")} titleTemplate={titleTemplate} />
       <GoogleAd id="myp3-standard-top" />
       <Page />
       <GoogleAd id="myp3-standard-bottom" />


### PR DESCRIPTION
There seems to be no `SEO.title` in `auth.json`. I replaced these occurrences with correct keys.