### PR TITLE
Use Webpack 5 and enable certain optimizations

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -7,9 +7,7 @@ const nextConfig = {
   webpack(config) {
     config.module.rules.push({
       test: /\.svg$/,
-      issuer: {
-        test: /\.(js|ts)x?$/,
-      },
+      include: /\.(js|ts)x?$/,
       use: ["@svgr/webpack"],
     });
 
@@ -21,6 +19,16 @@ const nextConfig = {
   publicRuntimeConfig: {
     NODE_ENV: process.env.NODE_ENV,
     BASE_PATH: process.env.BASE_PATH,
+  },
+  reactStrictMode: true,
+  experimental: {
+    optimizeFonts: true,
+    optimizeImages: true,
+    optimizeCss: true,
+  },
+  future: {
+    webpack5: true,
+    strictPostcssConfiguration: true,
   },
   async redirects() {
     return [

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "imagemin-optipng": "^8.0.0",
     "imagemin-svgo": "^8.0.0",
     "modern-normalize": "^1.0.0",
-    "next": "10.0.3",
+    "next": "10.1.2",
     "next-compose-plugins": "^2.2.1",
     "next-optimized-images": "^2.6.2",
     "next-seo": "^4.17.0",
@@ -60,7 +60,7 @@
     "react-transition-group": "^4.4.1",
     "responsive-loader": "^2.2.1",
     "sharp": "^0.26.3",
-    "styled-components": "^5.2.1",
+    "styled-components": "5.2.0",
     "styled-components-breakpoint": "^2.1.1",
     "svg-react-loader": "^0.4.6",
     "use-debounce": "^5.2.1"
@@ -82,6 +82,7 @@
     "babel-plugin-module-resolver": "^4.0.0",
     "babel-plugin-polished": "^1.1.0",
     "babel-plugin-styled-components": "^1.12.0",
+    "critters": "0.0.10",
     "eslint": "^7.15.0",
     "eslint-config-airbnb": "^18.2.1",
     "eslint-config-prettier": "^7.0.0",
@@ -95,5 +96,8 @@
     "graphql-codegen-apollo-next-ssr": "^1.2.1",
     "prettier": "^2.2.1",
     "typescript": "^4.1.3"
+  },
+  "resolutions": {
+    "webpack": "^5.28.0"
   }
 }


### PR DESCRIPTION
## Introduction

Webpack 5 enables better tree-shaking (although the size change is rather small - about 1 kB), certain optimizations and most importantly - **much better subsequent build times**.

## Benchmarks

Cached build time (Webpack 4):

```
npm run build  273,22s user 10,26s system 442% cpu 1:04,13 total
```

Cached build time (Webpack 5):

```
npm run build  42,08s user 6,12s system 223% cpu 21,564 total
```

## Other optimizations

- `reactStrictMode` enforces strict React checks to detect certain issues;
- `experimental.optimizeFonts` optimizes fonts using Webpack 5;
- `experimental.optimizeImages` enables additional image optimization via `next/image` (it currently does nothing, as we are not yet using `next/image`, but will be useful later);
- `experimental.optimizeCss` extracts critical CSS using Webpack 5 and `critters` module;
- `future.strictPostcssConfiguration` enables PostCSS cache to increase subsequent build speed.