### PR TITLE
Feature - Changes and save state tracking

### DIFF
--- a/locales/en/editor.json
+++ b/locales/en/editor.json
@@ -97,7 +97,8 @@
     }
   },
   "misc": {
-    "clickToConfirmAction": "Click again to confirm"
+    "clickToConfirmAction": "Click again to confirm",
+    "unsavedChangesWarning": "You have unsaved changes. Do you really want to leave this page?"
   },
   "admin": {
     "title": "Moderation panel",
@@ -106,6 +107,9 @@
     }
   },
   "footer": {
+    "saveButton": "Save",
+    "autoSaved": "Saved automatically",
+    "manuallySaved": "Saved",
     "urlTitle": "Link to the quiz",
     "urlToast": "Copied ",
     "testBeforeVerify": "Test before verification",

--- a/locales/pl/editor.json
+++ b/locales/pl/editor.json
@@ -97,7 +97,8 @@
     }
   },
   "misc": {
-    "clickToConfirmAction": "Naciśnij ponownie, aby potwierdzić"
+    "clickToConfirmAction": "Naciśnij ponownie, aby potwierdzić",
+    "unsavedChangesWarning": "Masz niezapisane zmiany. Czy na pewno chcesz opuścić tę stronę?"
   },
   "admin": {
     "title": "Panel moderacji",
@@ -106,6 +107,9 @@
     }
   },
   "footer": {
+    "saveButton": "Zapisz",
+    "autoSaved": "Zapisano automatycznie",
+    "manuallySaved": "Zapisano",
     "urlTitle": "Link do quizu:",
     "urlToast": "Skopiowano do schowka",
     "testBeforeVerify": "Przetestuj przed weryfikacją",

--- a/src/components/Editor/EditorContent/EditorContentView.tsx
+++ b/src/components/Editor/EditorContent/EditorContentView.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React from "react";
 import {
   Box,
   Question,
@@ -27,10 +27,13 @@ import EditorSlidingUpPanel, {
 } from "@components/Editor/EditorSlidingUpPanel";
 import useTranslation from "next-translate/useTranslation";
 import { Col, Row, Title, ToolboxCol } from "./EditorContentStyle";
+import useWarnIfUnsavedChanges from "@components/Editor/utils/useWarnIfUnsavedChanges";
 
 library.add(faPlus);
 
 const EditorContent: React.FC = () => {
+  useWarnIfUnsavedChanges();
+
   const { t } = useTranslation("editor");
   const { query } = useRouter();
   const editor = useEditor();

--- a/src/components/Editor/EditorFooter/EditorFooterStyle.ts
+++ b/src/components/Editor/EditorFooter/EditorFooterStyle.ts
@@ -34,6 +34,12 @@ export const Info = styled.div`
   }
 `;
 
+export const SaveContainer = styled.div`
+  font-weight: ${({ theme }) => theme.fontWeight.secondary.bold};
+  color: ${({ theme }) => theme.colors.green};
+  margin-bottom: 1rem;
+`;
+
 export const RequirementContainer = styled.div`
   display: grid;
   grid-template-columns: 2rem auto;

--- a/src/components/Editor/EditorFooter/EditorFooterView.tsx
+++ b/src/components/Editor/EditorFooter/EditorFooterView.tsx
@@ -7,6 +7,7 @@ import {
   faCopy,
   faFlask,
   faTimes,
+  faSave,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import Button from "@shared/Button";
@@ -27,14 +28,16 @@ import {
   RequirementContainer,
   RequirementIcon,
   Info,
+  SaveContainer,
 } from "./EditorFooterStyle";
 import {
   useRequirements,
   Requirement,
   TestedVersion,
 } from "./EditorFooterUtils";
+import { useChangeTracker } from "@components/Editor/utils/ChangeTrackerContext";
 
-library.add(faCheck, faTimes, faFlask, faCopy);
+library.add(faCheck, faTimes, faFlask, faCopy, faSave);
 
 interface Props {
   editor: UseEditor;
@@ -42,6 +45,7 @@ interface Props {
 
 const EditorFooter: React.FC<Props> = ({ editor }) => {
   const { t } = useTranslation("editor");
+  const { hasUncommittedChanges, commitChanges, lastSave } = useChangeTracker();
   const router = useRouter();
   const [loading, setLoading] = useState(false);
   const { actions, versionInput, basicInput, data } = editor;
@@ -126,9 +130,31 @@ const EditorFooter: React.FC<Props> = ({ editor }) => {
     setLoading(false);
   };
 
+  const handleSaveClick = async () => {
+    await commitChanges(false);
+  };
+
   return (
     <Container>
       <div>
+        <SaveContainer>
+          {hasUncommittedChanges ? (
+            <Button
+              onClick={handleSaveClick}
+              beforeIcon={<FontAwesomeIcon icon={faSave} />}
+            >
+              {t("footer.saveButton")}
+            </Button>
+          ) : (
+            <>
+              {t(
+                lastSave.autoSave ? "footer.autoSaved" : "footer.manuallySaved"
+              )}
+              &nbsp;
+              <FontAwesomeIcon icon={faCheck} />
+            </>
+          )}
+        </SaveContainer>
         <Info>
           {t("footer.urlTitle")}&nbsp;
           <span

--- a/src/components/Editor/EditorPage/EditorPageView.tsx
+++ b/src/components/Editor/EditorPage/EditorPageView.tsx
@@ -5,6 +5,7 @@ import { library } from "@fortawesome/fontawesome-svg-core";
 import { Content } from "@components/Editor";
 import useTranslation from "next-translate/useTranslation";
 import { Container, Header, IconWrapper, Title } from "./EditorPageStyle";
+import { ChangeTrackerProvider } from "@components/Editor/utils/ChangeTrackerContext";
 
 library.add(faPencilRuler);
 
@@ -22,7 +23,9 @@ const EditorPage: React.FC = () => {
         </div>
       </Header>
       <div>
-        <Content />
+        <ChangeTrackerProvider>
+          <Content />
+        </ChangeTrackerProvider>
       </div>
     </Container>
   );

--- a/src/components/Editor/EditorQuestion/utils/useQuestion.ts
+++ b/src/components/Editor/EditorQuestion/utils/useQuestion.ts
@@ -6,9 +6,8 @@ import {
   useUpdateQuestionMutation,
 } from "@generated/graphql";
 import { useEffect, useState } from "react";
-import { useDebounce } from "use-debounce";
 import useEntity from "@components/Editor/utils/useEntity";
-import { useDebounceCallback } from "@react-hook/debounce";
+import { useChangeTracker } from "@components/Editor/utils/ChangeTrackerContext";
 
 export interface EffectInput {
   type: "agree" | "disagree";
@@ -35,6 +34,7 @@ const useQuestion = (id: string): UseQuestion => {
     name: "Question",
     document: EditorQuestionPartsFragmentDoc,
   });
+  const { enqueueChange } = useChangeTracker();
   const [firstTime, setFirstTime] = useState(true);
   const [updateQuestion, { loading }] = useUpdateQuestionMutation();
 
@@ -107,8 +107,8 @@ const useQuestion = (id: string): UseQuestion => {
     };
   };
 
-  const handleUpdate = useDebounceCallback(
-    async () => {
+  const handleUpdate = () =>
+    enqueueChange(async () => {
       if (loading) {
         return;
       }
@@ -125,10 +125,7 @@ const useQuestion = (id: string): UseQuestion => {
       } catch (e) {
         console.error(e);
       }
-    },
-    5000,
-    false
-  );
+    }, id);
 
   useEffect(() => {
     if (firstTime) {

--- a/src/components/Editor/utils/ChangeTrackerContext.tsx
+++ b/src/components/Editor/utils/ChangeTrackerContext.tsx
@@ -1,0 +1,84 @@
+import React, { useCallback, useEffect, useState } from "react";
+
+type CommitFunc = () => Promise<void> | void;
+
+interface EntityChange {
+  id?: any;
+  commit: CommitFunc;
+}
+
+interface SaveInfo {
+  autoSave: boolean;
+}
+
+export interface ChangeTrackerContextType {
+  enqueueChange(func: CommitFunc, id: string): void;
+  commitChanges(isAutoSave: boolean): Promise<void>;
+  hasUncommittedChanges: boolean;
+  lastSave: SaveInfo;
+}
+
+const ChangeTrackerContext = React.createContext<ChangeTrackerContextType>(
+  undefined
+);
+
+export const useChangeTracker = () => React.useContext(ChangeTrackerContext);
+
+interface Props {
+  autoSaveInterval?: number;
+}
+
+export const ChangeTrackerProvider: React.FC<Props> = ({
+  children,
+  autoSaveInterval = 5000,
+}) => {
+  const [lastSave, setLastSave] = useState<SaveInfo>({
+    autoSave: false,
+  });
+  const [changesQueue, setChangesQueue] = useState<EntityChange[]>([]);
+
+  const commitChanges = useCallback(
+    async (isAutoSave: boolean = true) => {
+      while (changesQueue.length > 0) {
+        const change = changesQueue.shift();
+        await change.commit();
+      }
+      setChangesQueue([]);
+      setLastSave({ autoSave: isAutoSave });
+    },
+    [changesQueue]
+  );
+
+  useEffect(() => {
+    const intervalId = window.setInterval(commitChanges, autoSaveInterval);
+
+    return () => window.clearInterval(intervalId);
+  }, [autoSaveInterval, commitChanges]);
+
+  const enqueueChange = (func: CommitFunc, id: string) => {
+    setChangesQueue((previous) => {
+      const previousChange = previous.find(
+        (c) => c.id !== undefined && c.id === id
+      );
+      if (typeof previousChange !== "undefined") {
+        previousChange.commit = func;
+        return previous;
+      } else {
+        return [...previous, { commit: func, id }];
+      }
+    });
+  };
+
+  const value = {
+    enqueueChange,
+    commitChanges,
+    hasUncommittedChanges: changesQueue.length !== 0,
+    lastSave,
+  };
+
+  return (
+    <ChangeTrackerContext.Provider value={value}>
+      {children}
+    </ChangeTrackerContext.Provider>
+  );
+};

--- a/src/components/Editor/utils/useEditor.ts
+++ b/src/components/Editor/utils/useEditor.ts
@@ -4,13 +4,13 @@ import {
   UpdateQuizVersionInput,
 } from "@generated/graphql";
 import { useEffect } from "react";
-import { useDebounceCallback } from "@react-hook/debounce";
 import hash from "object-hash";
 import { useLanguages } from "./useLanguages";
 import useBasicInput from "./useBasicInput";
 import useVersionInput from "./useVersionInput";
 import useEditorData from "./useEditorData";
 import useEditorActions, { EditorActions } from "./useEditorActions";
+import { useChangeTracker } from "@components/Editor/utils/ChangeTrackerContext";
 
 export interface UseEditor {
   data: EditorQuizQueryHookResult;
@@ -20,6 +20,7 @@ export interface UseEditor {
 }
 
 export const useEditor = (): UseEditor => {
+  const { enqueueChange } = useChangeTracker();
   const data = useEditorData();
   const actions = useEditorActions();
   const versionInput = useVersionInput(data?.data);
@@ -29,29 +30,23 @@ export const useEditor = (): UseEditor => {
   const languages = useLanguages(data?.data);
   const languagesString = JSON.stringify(languages);
 
-  const handleVersionInput = useDebounceCallback(
-    async () => {
+  const handleVersionInput = () =>
+    enqueueChange(async () => {
       if (typeof versionInput === "undefined") {
         return;
       }
 
       await actions.updateVersion(versionInput);
-    },
-    5000,
-    false
-  );
+    }, "version");
 
-  const handleBasicInput = useDebounceCallback(
-    async () => {
+  const handleBasicInput = () =>
+    enqueueChange(async () => {
       if (typeof basicInput === "undefined") {
         return;
       }
 
       await actions.updateBasic(basicInput);
-    },
-    5000,
-    false
-  );
+    }, "basic");
 
   useEffect(() => {
     handleVersionInput();

--- a/src/components/Editor/utils/useEditorActions/useEditorTraitsActions.ts
+++ b/src/components/Editor/utils/useEditorActions/useEditorTraitsActions.ts
@@ -2,8 +2,6 @@ import { useEntityLazy } from "@components/Editor/utils/useEntity";
 import {
   EditorIdeologyPartsFragment,
   EditorIdeologyPartsFragmentDoc,
-  ResultsTraitPartsFragment,
-  ResultsTraitPartsFragmentDoc,
 } from "@generated/graphql";
 import {
   EditorGetCurrentDataFunction,

--- a/src/components/Editor/utils/useEntity.ts
+++ b/src/components/Editor/utils/useEntity.ts
@@ -1,7 +1,6 @@
 import { DocumentNode, useApolloClient } from "@apollo/client";
 import * as R from "ramda";
 import { DeepPartial } from "@typeDefs/common";
-import { useDebounceCallback } from '@react-hook/debounce';
 
 interface UseEntity<T> {
   data: T;

--- a/src/components/Editor/utils/useWarnIfUnsavedChanges.ts
+++ b/src/components/Editor/utils/useWarnIfUnsavedChanges.ts
@@ -1,0 +1,36 @@
+import { useEffect } from "react";
+import { useChangeTracker } from "@components/Editor/utils/ChangeTrackerContext";
+import { Router } from "next/router";
+import useTranslation from "next-translate/useTranslation";
+
+export const useWarnIfUnsavedChanges = () => {
+  const { t } = useTranslation("editor");
+  const { hasUncommittedChanges } = useChangeTracker();
+
+  useEffect(() => {
+    const message = t("misc.unsavedChangesWarning");
+
+    const handleRouteChangeStart = () => {
+      if (hasUncommittedChanges && !confirm(message)) {
+        throw "Route change was aborted. This error can be safely ignored.";
+      }
+    };
+
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      if (hasUncommittedChanges) {
+        e.preventDefault();
+        e.returnValue = message;
+      }
+    };
+
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    Router.events.on("routeChangeStart", handleRouteChangeStart);
+
+    return () => {
+      window.removeEventListener("beforeunload", handleBeforeUnload);
+      Router.events.off("routeChangeStart", handleRouteChangeStart);
+    };
+  }, [hasUncommittedChanges]);
+};
+
+export default useWarnIfUnsavedChanges;

--- a/src/shared/InternationalizedInput/InternationalizedInputView.tsx
+++ b/src/shared/InternationalizedInput/InternationalizedInputView.tsx
@@ -1,8 +1,7 @@
-import React, { ChangeEvent, useEffect, useState } from "react";
+import React, { ChangeEvent, useState } from "react";
 import LanguageSelect from "@shared/LanguageSelect";
 import useTranslation from "next-translate/useTranslation";
 import { TextTranslationInput } from "@generated/graphql";
-import { useDebounce } from "use-debounce";
 import { useDebounceCallback } from "@react-hook/debounce";
 import { Container, Input } from "./InternationalizedInputStyle";
 
@@ -20,10 +19,7 @@ const InternationalizedInput: React.FC<Props> = ({
   const { lang } = useTranslation();
   const [value, setValue] = useState<TextTranslationInput>(defaultValue);
   const [selectedLang, setSelectedLang] = useState<string>(lang);
-  const handleGlobalChange = useDebounceCallback(
-    (v) => onGlobalChange(v),
-    1000
-  );
+  const handleGlobalChange = useDebounceCallback((v) => onGlobalChange(v), 100);
 
   const handleControlledChange = (e: ChangeEvent<HTMLInputElement>) => {
     const newValue = {


### PR DESCRIPTION
This PR will provide users with information about the state of server/client quiz synchronization by:
- Notifying them about having unsaved changes
- Allowing them to save their changes whenever they want to
- Showing an alert before leaving the page if they have unsaved changes