### PR TITLE
Attempt to fix large icons when a page is loading

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -7,8 +7,12 @@ import Layout from "@layout";
 import Router from "next/router";
 import NProgress from "nprogress";
 import "modern-normalize/modern-normalize.css";
+import "@fortawesome/fontawesome-svg-core/styles.css";
+import { config } from '@fortawesome/fontawesome-svg-core';
 import { FacebookProvider } from "react-facebook";
 import useTranslation from "next-translate/useTranslation";
+
+config.autoAddCss = false;
 
 Router.events.on("routeChangeStart", () => NProgress.start());
 Router.events.on("routeChangeComplete", () => NProgress.done());

--- a/src/pages/results/[id].tsx
+++ b/src/pages/results/[id].tsx
@@ -14,7 +14,6 @@ import StandardPage, {
   getStandardPageProps,
   StandardPageProps,
 } from "@shared/StandardPage";
-import "@fortawesome/fontawesome-svg-core/styles.css";
 import { translate } from "@utils/translation";
 import { apiPaths } from "@constants";
 import {objToBase64} from "@utils/toBase64";


### PR DESCRIPTION
This is an attempt to fix the problem with large fontawesome icons during page load as suggested [here](https://github.com/FortAwesome/react-fontawesome/issues/134#issuecomment-421580721). Unfortunately, due to the nature of this problem, it's almost impossible to test the solution in a development environment.