### PR TITLE
Fix calculating invalid position on compass click

### DIFF
--- a/src/shared/Compass/CompassView.tsx
+++ b/src/shared/Compass/CompassView.tsx
@@ -19,7 +19,7 @@ const QuizCompassInput: React.FC<Props> = ({ value, onChange }) => {
     const round = (num) => Math.round((num + Number.EPSILON) * 100) / 100;
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
-    const compass = e.target.getBoundingClientRect();
+    const compass = e.currentTarget.getBoundingClientRect();
     const clickX = e.clientX - compass.x;
     const clickY = e.clientY - compass.y;
     const roundedX = round(clickX / compass.width);


### PR DESCRIPTION
Previously, the handler would take the position of the clicked element which could be the compass dot resulting in invalid calculations. This ensures we always use the correct element to do calculations.