### PR TITLE
Add reCAPTCHA error message

### DIFF
--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -60,6 +60,7 @@
     "9": "User does not exist",
     "10": "You have already voted",
     "11": "The verification email has already been sent. Try again in 15 minutes",
+    "12": "Missing reCAPTCHA",
     "default": "Unknown error"
   },
   "talkType": {

--- a/locales/pl/common.json
+++ b/locales/pl/common.json
@@ -60,6 +60,7 @@
     "9": "Użytkownik nie istnieje",
     "10": "Już oddałeś/oddałaś głos",
     "11": "Email weryfikacyjny został już wysłany. Spróbuj ponownie za 15 minut",
+    "12": "Brakująca reCAPTCHA",
     "default": "Nieznany błąd"
   },
   "talkType": {

--- a/src/components/Auth/AuthSignupPage/Form/FormView.tsx
+++ b/src/components/Auth/AuthSignupPage/Form/FormView.tsx
@@ -46,15 +46,22 @@ const FormView: React.FC = () => {
 
   const formik = useFormik({
     initialValues,
-    onSubmit: async ({ repeatEmail, ...values }) => {
-      try {
-        await createUser({
-          variables: {
-            values,
-          },
+    onSubmit: async (values) => {
+      if (!values.recaptcha) {
+        handleErrors({
+          code: 12,
+          text: "Missing reCAPTCHA",
         });
-      } catch (e) {
-        handleErrors(e);
+      } else {
+        try {
+          await createUser({
+            variables: {
+              values,
+            },
+          });
+        } catch (e) {
+          handleErrors(e);
+        }
       }
     },
     validationSchema: schema,


### PR DESCRIPTION
Currently, when a user does not complete reCAPTCHA and tries to either register or login they will receive an "Unknown error", as the server-side validation fails. This isn't very self-explanatory, is it?

I added a simple client-side reCAPTCHA validation, which blocks the request and throws a descriptive error message.